### PR TITLE
Update to use the https endpoints as the http endpoints are going away

### DIFF
--- a/lib/Flickr/API.pm
+++ b/lib/Flickr/API.pm
@@ -33,8 +33,8 @@ sub new {
 
 	$self->{api_key}	= $options->{key};
 	$self->{api_secret}	= $options->{secret};
-	$self->{rest_uri}	= $options->{rest_uri} || 'http://api.flickr.com/services/rest/';
-	$self->{auth_uri}	= $options->{auth_uri} || 'http://api.flickr.com/services/auth/';
+	$self->{rest_uri}	= $options->{rest_uri} || 'https://api.flickr.com/services/rest/';
+	$self->{auth_uri}	= $options->{auth_uri} || 'https://api.flickr.com/services/auth/';
 	$self->{unicode}	= $options->{unicode} || 0;
 
 	eval {

--- a/t/01-test.t
+++ b/t/01-test.t
@@ -83,7 +83,7 @@ foreach my $item (keys %got) {
 
 is($uri->path, '/services/auth/', "Checking correct return path");
 is($uri->host, 'api.flickr.com', "Checking return domain");
-is($uri->scheme, 'http', "Checking return protocol");
+is($uri->scheme, 'https', "Checking return protocol");
 
 
 ##################################################


### PR DESCRIPTION
This is a very small change that updates the default Flickr URLs so that they use SSL to connect. This old HTTP URLs will stop working at the end of the month.
