### PR TITLE
avoid an undef warning when checking auth type

### DIFF
--- a/lib/Flickr/API/Request.pm
+++ b/lib/Flickr/API/Request.pm
@@ -16,7 +16,7 @@ sub new {
     my $options = shift;
     my $self;
 
-    if ($options->{api_type} eq 'oauth') {
+    if (($options->{api_type} || '') eq 'oauth') {
 
         $options->{args}->{request_method}='POST';
         $options->{args}->{request_url}=$options->{rest_uri};


### PR DESCRIPTION
When no auth type is explicit, we shouldn't use `eq` on undef.