### PR TITLE
Update 06-oauth-authenticated-methods.t lifting 5.10 restriction

### DIFF
--- a/t/06-oauth-authenticated-methods.t
+++ b/t/06-oauth-authenticated-methods.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More tests => 17;
 use Storable;
 use Flickr::API;
-use 5.010;
 
 
 my $config_file;


### PR DESCRIPTION
I see no need to have this test restrict to 5.10, the module itself does not have any restrictions on Perl itself either