### PR TITLE
change error code for "method not found" from 112 to 212

### DIFF
--- a/t/01-test.t
+++ b/t/01-test.t
@@ -29,7 +29,7 @@ SKIP: {
 	skip "skipping error code check, since we couldn't reach the API", 1
 		if $rsp->rc() ne '200';
 	# this error code may change in future!
-	is($rsp->error_code(), 112, 'checking the error code for "method not found"');
+	is($rsp->error_code(), 212, 'checking the error code for "method not found"');
 }
 
 

--- a/t/03-flickr_api.t
+++ b/t/03-flickr_api.t
@@ -54,7 +54,7 @@ SKIP: {
 		skip "skipping error code check, since we couldn't reach the API", 1
 		  if $rsp->rc() ne '200';
 		# this error code may change in future!
-		is($rsp->error_code(), 112, 'checking the error code for "method not found"');
+		is($rsp->error_code(), 212, 'checking the error code for "method not found"');
 	}
 
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Flickr-API.
We thought you might be interested in it too.

    Description: change error code for "method not found" from 112 to 212
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1064755
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-02-25
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libflickr-api-perl/raw/master/debian/patches/method-not-found.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
